### PR TITLE
Add tutors and tutoring relation

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -12,23 +12,55 @@ type Course struct {
 	Name string `gorm:"not null" json:"name"`
 }
 
+type Tutor struct {
+	ID       uint   `gorm:"primaryKey" json:"-"`
+	Username string `gorm:"unique,not null" json:"username"`
+}
+
+//TODO: May be possible with Gorm many2many, but will likely add columns
+type Tutoring struct {
+	TutorID  uint   `json:"-"`
+	Tutor    Tutor  `gorm:"foreignKey:TutorID" json:"tutor"`
+	CourseID uint   `json:"-"`
+	Course   Course `gorm:"foreignKey:CourseID" json:"course"`
+}
+
 func main() {
 	//TODO: Initialization errors
 	db, _ := gorm.Open(sqlite.Open("database.db"), &gorm.Config{})
-	_ = db.AutoMigrate(&Course{})
+	_ = db.AutoMigrate(&Course{}, &Tutor{}, &Tutoring{})
 
 	//TODO: Test data initialization script
 	/*
-		db.Create(&Course{Code: "cop-3502", Name: "Programming Fundamentals 1"})
-		db.Create(&Course{Code: "cop-3503", Name: "Programming Fundamentals 2"})
-		db.Create(&Course{Code: "cot-3100", Name: "Applications of Discrete Structures"})
-		db.Create(&Course{Code: "cop-3530", Name: "Data Structures and Algorithms"})
-		db.Create(&Course{Code: "cen-3031", Name: "Introduction to Computer Organization"})
-		db.Create(&Course{Code: "cda-3101", Name: "Introduction to Software Engineering"})
-		db.Create(&Course{Code: "cis-4301", Name: "Information and Database Systems"})
-		db.Create(&Course{Code: "cop-4020", Name: "Programming Language Concepts"})
-		db.Create(&Course{Code: "cop-4600", Name: "Operating Systems"})
-		db.Create(&Course{Code: "cnt-4007", Name: "Computer Network Fundamentals"})
+		courses := []Course{
+			{Code: "cop-3502", Name: "Programming Fundamentals 1"},
+			{Code: "cop-3503", Name: "Programming Fundamentals 2"},
+			{Code: "cot-3100", Name: "Applications of Discrete Structures"},
+			{Code: "cop-3530", Name: "Data Structures and Algorithms"},
+			{Code: "cen-3031", Name: "Introduction to Computer Organization"},
+			{Code: "cda-3101", Name: "Introduction to Software Engineering"},
+			{Code: "cis-4301", Name: "Information and Database Systems"},
+			{Code: "cop-4020", Name: "Programming Language Concepts"},
+			{Code: "cop-4600", Name: "Operating Systems"},
+			{Code: "cnt-4007", Name: "Computer Network Fundamentals"},
+		}
+		db.Create(courses)
+
+		tutors := []Tutor{
+			{Username: "Alice"},
+			{Username: "Bob"},
+			{Username: "Clair"},
+			{Username: "David"},
+		}
+		db.Create(tutors)
+
+		tutoring := []Tutoring{
+			{Tutor: tutors[0], Course: courses[0]},
+			{Tutor: tutors[1], Course: courses[0]},
+			{Tutor: tutors[1], Course: courses[1]},
+			{Tutor: tutors[2], Course: courses[2]},
+		}
+		db.Create(tutoring)
 	*/
 
 	r := gin.Default()
@@ -47,12 +79,52 @@ func main() {
 		var courses []Course
 		db.Limit(1).Find(&courses, "code = ?", code)
 		if len(courses) == 1 {
+			//TODO: Native Gorm handling with Pluck (Preload/Join extract?)
+			var tutorings []Tutoring
+			db.Preload("Tutor").Find(&tutorings, "course_id = ?", courses[0].ID)
+			var tutors []Tutor
+			for _, tutoring := range tutorings {
+				tutors = append(tutors, tutoring.Tutor)
+			}
 			c.JSON(200, gin.H{
 				"course": courses[0],
+				"tutors": tutors,
 			})
 		} else {
 			c.JSON(404, gin.H{
 				"error": "Course " + code + " not found.",
+			})
+		}
+	})
+
+	r.GET("/tutors", func(c *gin.Context) {
+		//TODO: Pagination support
+		var tutors []Tutor
+		db.Order("username").Find(&tutors)
+		c.JSON(200, gin.H{
+			"tutors": tutors,
+		})
+	})
+
+	r.GET("/tutors/:username", func(c *gin.Context) {
+		username := c.Params.ByName("username")
+		var tutors []Tutor
+		db.Limit(1).Find(&tutors, "username = ?", username)
+		if len(tutors) == 1 {
+			//TODO: Native Gorm handling with Pluck (Preload/Join extract?)
+			var tutorings []Tutoring
+			db.Preload("Course").Find(&tutorings, "tutor_id = ?", tutors[0].ID)
+			var courses []Course
+			for _, tutoring := range tutorings {
+				courses = append(courses, tutoring.Course)
+			}
+			c.JSON(200, gin.H{
+				"tutor":   tutors[0],
+				"courses": courses,
+			})
+		} else {
+			c.JSON(404, gin.H{
+				"error": "Tutor " + username + " not found.",
 			})
 		}
 	})


### PR DESCRIPTION
The Tutoring table is done manually since we will likely be adding additional columns (ex. price) later on. Furthermore, getting the tutor or course from the relation is messy due to preloading; using a join is likely a better solution and may allow the tutor fields to be extracted directly.