### PR TITLE
Add backend testing support and implement tests

### DIFF
--- a/backend/cmd/initdb/main.go
+++ b/backend/cmd/initdb/main.go
@@ -6,7 +6,7 @@ import (
 
 func main() {
 	//TODO: Error handling
-	src.InitDatabase()
+	src.InitDatabase("database.db")
 
 	courses := []src.Course{
 		{Code: "cop-3502", Name: "Programming Fundamentals 1"},

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -6,7 +6,7 @@ import (
 
 func main() {
 	//TODO: Error handling
-	src.InitDatabase()
+	src.InitDatabase("database.db")
 	src.InitRouter()
 	_ = src.Router.Run(":8080")
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require github.com/gin-gonic/gin v1.7.7
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.13.0 // indirect
 	github.com/go-playground/universal-translator v0.17.0 // indirect
@@ -18,10 +19,14 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.10 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/ugorji/go/codec v1.1.7 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
 	golang.org/x/sys v0.0.0-20200116001909-b77594299b42 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 	gorm.io/driver/sqlite v1.2.6 // indirect
 	gorm.io/gorm v1.22.5 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -36,6 +36,7 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
@@ -61,6 +62,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/sqlite v1.2.6 h1:SStaH/b+280M7C8vXeZLz/zo9cLQmIGwwj3cSj7p6l4=
 gorm.io/driver/sqlite v1.2.6/go.mod h1:gyoX0vHiiwi0g49tv+x2E7l8ksauLK0U/gShcdUsjWY=

--- a/backend/src/database.go
+++ b/backend/src/database.go
@@ -7,10 +7,10 @@ import (
 
 var DB *gorm.DB
 
-func InitDatabase() {
+func InitDatabase(dsn string) {
 	//TODO: Error handling
 	//TODO: Fix relative path use (relative from cmd/<cmd>)
-	DB, _ = gorm.Open(sqlite.Open("../../database.db"), &gorm.Config{})
+	DB, _ = gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	_ = DB.AutoMigrate(&Course{}, &Tutor{}, &Tutoring{})
 }
 

--- a/backend/src/router.go
+++ b/backend/src/router.go
@@ -30,8 +30,8 @@ func getCoursesCode(c *gin.Context) {
 	if len(courses) == 1 {
 		//TODO: Native Gorm handling with Pluck (Preload/Join extract?)
 		var tutorings []Tutoring
-		DB.Preload("Tutor").Find(&tutorings, "course_id = ?", courses[0].ID)
-		var tutors []Tutor
+		DB.Joins("Tutor").Order("Tutor__username").Find(&tutorings, "course_id = ?", courses[0].ID)
+		tutors := []Tutor{}
 		for _, tutoring := range tutorings {
 			tutors = append(tutors, tutoring.Tutor)
 		}
@@ -62,8 +62,8 @@ func getTutorsUsername(c *gin.Context) {
 	if len(tutors) == 1 {
 		//TODO: Native Gorm handling with Pluck (Preload/Join extract?)
 		var tutorings []Tutoring
-		DB.Preload("Course").Find(&tutorings, "tutor_id = ?", tutors[0].ID)
-		var courses []Course
+		DB.Joins("Course").Order("Course__code").Find(&tutorings, "tutor_id = ?", tutors[0].ID)
+		courses := []Course{}
 		for _, tutoring := range tutorings {
 			courses = append(courses, tutoring.Course)
 		}

--- a/backend/src/router_test.go
+++ b/backend/src/router_test.go
@@ -85,6 +85,78 @@ func (suite *RouterSuite) TestGetCourses() {
 	))
 }
 
+func (suite *RouterSuite) TestGetCoursesCode() {
+	//Fix ID to ensure multiple references use the same course
+	course := Course{ID: 1, Code: "code", Name: "Name"}
+
+	test := func(tutorings []Tutoring, expected string) func() {
+		return manualSetupTest(func() {
+			DB.Create(&course)
+			DB.Create(tutorings)
+			w := request("GET", "/courses/"+course.Code)
+			suite.Equal(200, w.Code)
+			suite.JSONEq(expected, w.Body.String())
+		})
+	}
+
+	suite.Run("Empty Tutors", test(
+		[]Tutoring{},
+		`{
+			"course": {"code": "code", "name": "Name"},
+			"tutors": []
+		}`,
+	))
+
+	suite.Run("Single Tutor", test(
+		[]Tutoring{
+			{Course: course, Tutor: Tutor{Username: "Username"}},
+		},
+		`{
+			"course": {"code": "code", "name": "Name"},
+			"tutors": [
+				{"username": "Username"}
+			]
+		}`,
+	))
+
+	suite.Run("Multiple Tutors", test(
+		[]Tutoring{
+			{Course: course, Tutor: Tutor{Username: "Alice"}},
+			{Course: course, Tutor: Tutor{Username: "Bob"}},
+			{Course: course, Tutor: Tutor{Username: "Clair"}},
+		},
+		`{
+			"course": {"code": "code", "name": "Name"},
+			"tutors": [
+				{"username": "Alice"},
+				{"username": "Bob"},
+				{"username": "Clair"}
+			]
+		}`,
+	))
+
+	suite.Run("Tutors Order", test(
+		[]Tutoring{
+			{Course: course, Tutor: Tutor{Username: "Clair"}},
+			{Course: course, Tutor: Tutor{Username: "Bob"}},
+			{Course: course, Tutor: Tutor{Username: "Alice"}},
+		},
+		`{
+			"course": {"code": "code", "name": "Name"},
+			"tutors": [
+				{"username": "Alice"},
+				{"username": "Bob"},
+				{"username": "Clair"}
+			]
+		}`,
+	))
+
+	suite.Run("Undefined Code", manualSetupTest(func() {
+		w := request("GET", "/courses/undefined")
+		suite.Equal(404, w.Code)
+	}))
+}
+
 func (suite *RouterSuite) TestGetTutors() {
 	test := func(tutors []Tutor, expected string) func() {
 		return manualSetupTest(func() {
@@ -142,6 +214,78 @@ func (suite *RouterSuite) TestGetTutors() {
 			]
 		}`,
 	))
+}
+
+func (suite *RouterSuite) TestGetTutorsUsername() {
+	//Fix ID to ensure multiple references use the same tutor
+	tutor := Tutor{ID: 1, Username: "Username"}
+
+	test := func(tutorings []Tutoring, expected string) func() {
+		return manualSetupTest(func() {
+			DB.Create(&tutor)
+			DB.Create(tutorings)
+			w := request("GET", "/tutors/"+tutor.Username)
+			suite.Equal(200, w.Code)
+			suite.JSONEq(expected, w.Body.String())
+		})
+	}
+
+	suite.Run("Empty Courses", test(
+		[]Tutoring{},
+		`{
+			"tutor": {"username": "Username"},
+			"courses": []
+		}`,
+	))
+
+	suite.Run("Single Tutor", test(
+		[]Tutoring{
+			{Course: Course{Code: "code", Name: "Name"}, Tutor: tutor},
+		},
+		`{
+			"tutor": {"username": "Username"},
+			"courses": [
+				{"code": "code", "name": "Name"}
+			]
+		}`,
+	))
+
+	suite.Run("Multiple Tutors", test(
+		[]Tutoring{
+			{Course: Course{Code: "1", Name: "First"}, Tutor: tutor},
+			{Course: Course{Code: "2", Name: "Second"}, Tutor: tutor},
+			{Course: Course{Code: "3", Name: "Third"}, Tutor: tutor},
+		},
+		`{
+			"tutor": {"username": "Username"},
+			"courses": [
+				{"code": "1", "name": "First"},
+				{"code": "2", "name": "Second"},
+				{"code": "3", "name": "Third"}
+			]
+		}`,
+	))
+
+	suite.Run("Courses Order", test(
+		[]Tutoring{
+			{Course: Course{Code: "3", Name: "Third"}, Tutor: tutor},
+			{Course: Course{Code: "2", Name: "Second"}, Tutor: tutor},
+			{Course: Course{Code: "1", Name: "First"}, Tutor: tutor},
+		},
+		`{
+			"tutor": {"username": "Username"},
+			"courses": [
+				{"code": "1", "name": "First"},
+				{"code": "2", "name": "Second"},
+				{"code": "3", "name": "Third"}
+			]
+		}`,
+	))
+
+	suite.Run("Undefined Username", manualSetupTest(func() {
+		w := request("GET", "/tutors/undefined")
+		suite.Equal(404, w.Code)
+	}))
 }
 
 func request(method string, path string) *httptest.ResponseRecorder {

--- a/backend/src/router_test.go
+++ b/backend/src/router_test.go
@@ -1,0 +1,152 @@
+package src
+
+import (
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRouterSuite(t *testing.T) {
+	suite.Run(t, new(RouterSuite))
+}
+
+type RouterSuite struct {
+	suite.Suite
+}
+
+func (suite *RouterSuite) SetupSuite() {
+	InitRouter()
+}
+
+func manualSetupTest(test func()) func() {
+	return func() {
+		InitDatabase("file::memory:")
+		test()
+	}
+}
+
+func (suite *RouterSuite) TestGetCourses() {
+	test := func(courses []Course, expected string) func() {
+		return manualSetupTest(func() {
+			DB.Create(courses)
+			w := request("GET", "/courses")
+			suite.Equal(200, w.Code)
+			suite.JSONEq(expected, w.Body.String())
+		})
+	}
+
+	suite.Run("Empty", test(
+		[]Course{},
+		`{
+			"courses": []
+		}`,
+	))
+
+	suite.Run("Single", test(
+		[]Course{
+			{Code: "code", Name: "Name"},
+		},
+		`{
+			"courses": [
+				{"code": "code", "name": "Name"}
+			]
+		}`,
+	))
+
+	suite.Run("Multiple", test(
+		[]Course{
+			{Code: "1", Name: "First"},
+			{Code: "2", Name: "Second"},
+			{Code: "3", Name: "Third"},
+		},
+		`{
+			"courses": [
+				{"code": "1", "name": "First"},
+				{"code": "2", "name": "Second"},
+				{"code": "3", "name": "Third"}
+			]
+		}`,
+	))
+
+	suite.Run("Order", test(
+		[]Course{
+			{Code: "3", Name: "Third"},
+			{Code: "2", Name: "Second"},
+			{Code: "1", Name: "First"},
+		},
+		`{
+			"courses": [
+				{"code": "1", "name": "First"},
+				{"code": "2", "name": "Second"},
+				{"code": "3", "name": "Third"}
+			]
+		}`,
+	))
+}
+
+func (suite *RouterSuite) TestGetTutors() {
+	test := func(tutors []Tutor, expected string) func() {
+		return manualSetupTest(func() {
+			DB.Create(tutors)
+			w := request("GET", "/tutors")
+			suite.Equal(200, w.Code)
+			suite.JSONEq(expected, w.Body.String())
+		})
+	}
+
+	suite.Run("Empty", test(
+		[]Tutor{},
+		`{
+			"tutors": []
+		}`,
+	))
+
+	suite.Run("Single", test(
+		[]Tutor{
+			{Username: "Username"},
+		},
+		`{
+			"tutors": [
+				{"username": "Username"}
+			]
+		}`,
+	))
+
+	suite.Run("Multiple", test(
+		[]Tutor{
+			{Username: "Alice"},
+			{Username: "Bob"},
+			{Username: "Clair"},
+		},
+		`{
+			"tutors": [
+				{"username": "Alice"},
+				{"username": "Bob"},
+				{"username": "Clair"}
+			]
+		}`,
+	))
+
+	suite.Run("Order", test(
+		[]Tutor{
+			{Username: "Clair"},
+			{Username: "Bob"},
+			{Username: "Alice"},
+		},
+		`{
+			"tutors": [
+				{"username": "Alice"},
+				{"username": "Bob"},
+				{"username": "Clair"}
+			]
+		}`,
+	))
+}
+
+func request(method string, path string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(method, path, nil)
+	Router.ServeHTTP(w, req)
+	return w
+}


### PR DESCRIPTION
This uses testify.suite for test setup to initialize the router. The InitDatabase function now takes a dsn string to allow tests to run with an in-memory database. Furthermore, testify does not appear to support setup before subtests so tests are wrapped with a manualSetupTest function.