### PR TITLE
Normalize database schema for User/Tutor

### DIFF
--- a/backend/cmd/initdb/main.go
+++ b/backend/cmd/initdb/main.go
@@ -8,6 +8,18 @@ func main() {
 	//TODO: Error handling
 	src.InitDatabase("database.db")
 
+	users := []src.User{
+		{Username: "Alice", FirstName: "Alice", LastName: "Smith", Email: "alicemsmith@gmail.com", Phone: "(567) 890-1234"},
+		{Username: "Bob", FirstName: "Bob", LastName: "Crachett", Email: "bobbyc@gmail.com", Phone: "(678) 901-2345"},
+		{Username: "Clair", FirstName: "Clair", LastName: "Carson", Email: "claircarson@gmail.com", Phone: "(789) 012-3456"},
+		{Username: "David", FirstName: "David", LastName: "Davidson", Email: "davidsquared@outlook.com", Phone: "(890) 123-4567"},
+		{Username: "Eve", FirstName: "Evangeline", LastName: "Mae", Email: "emae@gmail.com", Phone: "(123) 456-7890"},
+		{Username: "Fred", FirstName: "Fred", LastName: "Flinstone", Email: "freddyflint@aol.com", Phone: "(234) 567-8901"},
+		{Username: "Greta", FirstName: "Greta", LastName: "Glade", Email: "gg@hotmail.com", Phone: "(345) 678-9012"},
+		{Username: "Henry", FirstName: "Henry", LastName: "Hue", Email: "henrytheeight@ufl.edu", Phone: "(456) 789-0123"},
+	}
+	src.DB.Create(users)
+
 	courses := []src.Course{
 		{Code: "cop-3502", Name: "Programming Fundamentals 1"},
 		{Code: "cop-3503", Name: "Programming Fundamentals 2"},
@@ -23,13 +35,13 @@ func main() {
 	src.DB.Create(courses)
 
 	tutors := []src.Tutor{
-		{Username: "Alice", Rating: 5.0, Bio: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},
-		{Username: "Bob", Rating: 4.5, Bio: "Once upon a midnight dreary, while I pondered, weak and weary, Over many a quaint and curious volume of forgotten lore—While I nodded, nearly napping, suddenly there came a tapping, As of some one gently rapping, rapping at my chamber door. `Tis some visitor,` I muttered, `tapping at my chamber door—Only this and nothing more.`"},
-		{Username: "Clair", Rating: 2.0, Bio: "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven, we were all going direct the other way--in short, the period was so far like the present period that some of its noisiest authorities insisted on its being received, for good or for evil, in the superlative degree of comparison only."},
-		{Username: "David", Rating: 0.0, Bio: "There once was a ship that put to sea. The name of the ship was the Billy of Tea. The winds blew up, her bow dipped down. O blow, my bully boys, blow. Soon may the Wellerman come. To bring us sugar and tea and rum. One day, when the tonguin' is done. We'll take our leave and go."},
+		{User: users[0], Rating: 5.0, Bio: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},
+		{User: users[1], Rating: 4.5, Bio: "Once upon a midnight dreary, while I pondered, weak and weary, Over many a quaint and curious volume of forgotten lore—While I nodded, nearly napping, suddenly there came a tapping, As of some one gently rapping, rapping at my chamber door. `Tis some visitor,` I muttered, `tapping at my chamber door—Only this and nothing more.`"},
+		{User: users[2], Rating: 2.0, Bio: "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven, we were all going direct the other way--in short, the period was so far like the present period that some of its noisiest authorities insisted on its being received, for good or for evil, in the superlative degree of comparison only."},
+		{User: users[3], Rating: 0.0, Bio: "There once was a ship that put to sea. The name of the ship was the Billy of Tea. The winds blew up, her bow dipped down. O blow, my bully boys, blow. Soon may the Wellerman come. To bring us sugar and tea and rum. One day, when the tonguin' is done. We'll take our leave and go."},
 	}
 	src.DB.Create(tutors)
-	
+
 	availability := []src.Availability{
 		{Tutor: tutors[0], Day: "Monday"},
 		{Tutor: tutors[1], Day: "Tuesday"},
@@ -47,16 +59,4 @@ func main() {
 		{Tutor: tutors[2], Course: courses[2]},
 	}
 	src.DB.Create(tutoring)
-	
-	users := []src.User{
-		{Username: "Eve", FirstName: "Evangeline", LastName: "Mae", Email: "emae@gmail.com", Phone: "(123) 456-7890"},
-		{Username: "Fred", FirstName: "Fred", LastName: "Flinstone", Email: "freddyflint@aol.com", Phone: "(234) 567-8901"},
-		{Username: "Greta", FirstName: "Greta", LastName: "Glade", Email: "gg@hotmail.com", Phone: "(345) 678-9012"},
-		{Username: "Henry", FirstName: "Henry", LastName: "Hue", Email: "henrytheeight@ufl.edu", Phone: "(456) 789-0123"},
-		{Username: "Alice", FirstName: "Alice", LastName: "Smith", Email: "alicemsmith@gmail.com", Phone: "(567) 890-1234"},
-		{Username: "Bob", FirstName: "Bob", LastName: "Crachett", Email: "bobbyc@gmail.com", Phone: "(678) 901-2345"},
-		{Username: "Clair", FirstName: "Clair", LastName: "Carson", Email: "claircarson@gmail.com", Phone: "(789) 012-3456"},
-		{Username: "David", FirstName: "David", LastName: "Davidson", Email: "davidsquared@outlook.com", Phone: "(890) 123-4567"},
-	}
-	src.DB.Create(users)
 }

--- a/backend/src/database.go
+++ b/backend/src/database.go
@@ -10,7 +10,17 @@ var DB *gorm.DB
 func InitDatabase(dsn string) {
 	//TODO: Error handling
 	DB, _ = gorm.Open(sqlite.Open(dsn), &gorm.Config{})
-	_ = DB.AutoMigrate(&Course{}, &Tutor{}, &Availability{}, &Tutoring{}, &User{})
+	_ = DB.AutoMigrate(&User{}, &Course{}, &Tutor{}, &Availability{}, &Tutoring{})
+}
+
+type User struct {
+	ID        uint   `gorm:"primaryKey" json:"-"`
+	Username  string `gorm:"unique,not null" json:"username"`
+	Password  string `gorm:"not null" json:"-"`
+	FirstName string `gorm:"not null" json:"firstname"`
+	LastName  string `gorm:"not null" json:"lastname"`
+	Email     string `gorm:"not null" json:"email"`
+	Phone     string `gorm:"not null" json:"phone"`
 }
 
 type Course struct {
@@ -20,10 +30,11 @@ type Course struct {
 }
 
 type Tutor struct {
-	ID       uint    `gorm:"primaryKey" json:"-"`
-	Username string  `gorm:"unique,not null" json:"username"`
-	Rating   float32 `gorm:"not null" json:"rating"`
-	Bio      string  `json:"bio"`
+	UserID       uint           `json:"-"`
+	User         User           `gorm:"foreignKey:UserID" json:"user"`
+	Rating       float32        `gorm:"not null" json:"rating"`
+	Bio          string         `json:"bio"`
+	Availability []Availability `json:"availability"`
 }
 
 type Availability struct {
@@ -37,15 +48,4 @@ type Tutoring struct {
 	Tutor    Tutor  `gorm:"foreignKey:TutorID" json:"tutor"`
 	CourseID uint   `json:"-"`
 	Course   Course `gorm:"foreignKey:CourseID" json:"course"`
-}
-
-type User struct {
-	ID        uint   `json:"-"`
-	Username  string `gorm:"unique,not null" json:"username"`
-	Password  string `gorm:"not null" json:"-"`
-	FirstName string `gorm:"not null" json:"firstname"`
-	LastName  string `gorm:"not null" json:"lastname"`
-	Email     string `gorm:"not null" json:"email"`
-	Phone     string `gorm:"not null" json:"phone"`
-	//TODO: Add other attributes
 }

--- a/backend/src/router_test.go
+++ b/backend/src/router_test.go
@@ -113,7 +113,7 @@ func (suite *RouterSuite) TestGetCoursesCode() {
 
 	suite.Run("Single Tutor", test(
 		[]Tutoring{
-			{Course: course, Tutor: Tutor{Username: "Username"}},
+			{Course: course, Tutor: Tutor{User: User{Username: "Username"}}},
 		},
 		`{
 			"course": {"code": "code", "name": "Name"},
@@ -125,9 +125,9 @@ func (suite *RouterSuite) TestGetCoursesCode() {
 
 	suite.Run("Multiple Tutors", test(
 		[]Tutoring{
-			{Course: course, Tutor: Tutor{Username: "Alice"}},
-			{Course: course, Tutor: Tutor{Username: "Bob"}},
-			{Course: course, Tutor: Tutor{Username: "Clair"}},
+			{Course: course, Tutor: Tutor{User: User{Username: "Alice"}}},
+			{Course: course, Tutor: Tutor{User: User{Username: "Bob"}}},
+			{Course: course, Tutor: Tutor{User: User{Username: "Clair"}}},
 		},
 		`{
 			"course": {"code": "code", "name": "Name"},
@@ -141,9 +141,9 @@ func (suite *RouterSuite) TestGetCoursesCode() {
 
 	suite.Run("Tutors Order", test(
 		[]Tutoring{
-			{Course: course, Tutor: Tutor{Username: "Clair"}},
-			{Course: course, Tutor: Tutor{Username: "Bob"}},
-			{Course: course, Tutor: Tutor{Username: "Alice"}},
+			{Course: course, Tutor: Tutor{User: User{Username: "Clair"}}},
+			{Course: course, Tutor: Tutor{User: User{Username: "Bob"}}},
+			{Course: course, Tutor: Tutor{User: User{Username: "Alice"}}},
 		},
 		`{
 			"course": {"code": "code", "name": "Name"},
@@ -180,7 +180,7 @@ func (suite *RouterSuite) TestGetTutors() {
 
 	suite.Run("Single", test(
 		[]Tutor{
-			{Username: "Username"},
+			{User: User{Username: "Username"}},
 		},
 		`{
 			"tutors": [
@@ -191,9 +191,9 @@ func (suite *RouterSuite) TestGetTutors() {
 
 	suite.Run("Multiple", test(
 		[]Tutor{
-			{Username: "Alice"},
-			{Username: "Bob"},
-			{Username: "Clair"},
+			{User: User{Username: "Alice"}},
+			{User: User{Username: "Bob"}},
+			{User: User{Username: "Clair"}},
 		},
 		`{
 			"tutors": [
@@ -206,9 +206,9 @@ func (suite *RouterSuite) TestGetTutors() {
 
 	suite.Run("Order", test(
 		[]Tutor{
-			{Username: "Clair"},
-			{Username: "Bob"},
-			{Username: "Alice"},
+			{User: User{Username: "Clair"}},
+			{User: User{Username: "Bob"}},
+			{User: User{Username: "Alice"}},
 		},
 		`{
 			"tutors": [
@@ -222,13 +222,13 @@ func (suite *RouterSuite) TestGetTutors() {
 
 func (suite *RouterSuite) TestGetTutorsUsername() {
 	//Fix ID to ensure multiple references use the same tutor
-	tutor := Tutor{ID: 1, Username: "Username"}
+	tutor := Tutor{User: User{ID: 1, Username: "Username"}}
 
 	test := func(tutorings []Tutoring, expected string) func() {
 		return manualSetupTest(func() {
 			DB.Create(&tutor)
 			DB.Create(tutorings)
-			w := GET("/tutors/" + tutor.Username)
+			w := GET("/tutors/" + tutor.User.Username)
 			suite.Equal(200, w.Code)
 			suite.JSONEq(expected, w.Body.String())
 		})


### PR DESCRIPTION
This ensures `Username` is not duplicated and user information is accessible through `Tutor`. However, the queries are a bit of a hodgepodge of `Joins`/`Preload` calls for this; it's not optimal but functional. Other schema changes down the road will help with this, as will almost certainly moving towards more raw queries.