### PR TITLE
Revert "Add default vals for new user"

### DIFF
--- a/backend/src/router.go
+++ b/backend/src/router.go
@@ -220,7 +220,7 @@ func postSignup(c *gin.Context) {
 	}
 
 	hash, _ := bcrypt.GenerateFromPassword([]byte(body.Password), bcrypt.DefaultCost)
-	DB.Create(&User{Username: body.Username, Password: string(hash), FirstName: "Anonymous", LastName: "", Email: "unknown email", Phone: "unknown number"})
+	DB.Create(&User{Username: body.Username, Password: string(hash)})
 
 	token, err := CreateJWT(body.Username)
 	if err != nil {


### PR DESCRIPTION
Reverts WillBAnders/TutorsVILLE#95. The default value stored should always be an empty string by convention for Go. Some of the defaults here also break validation, such as `"unknown email"` not being a valid email address - accidentally using these values could cause problems down the line.