### PR TITLE
Refactor API to join user/tutor data

### DIFF
--- a/backend/src/database.go
+++ b/backend/src/database.go
@@ -1,8 +1,10 @@
 package src
 
 import (
+	"encoding/json"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"strings"
 )
 
 var DB *gorm.DB
@@ -30,12 +32,26 @@ type Course struct {
 }
 
 type Tutor struct {
-	UserID       uint    `gorm:"primaryKey" json:"-"`
-	User         User    `gorm:"foreignKey:UserID" json:"user"`
-	Rating       float32 `gorm:"not null" json:"rating"`
-	Bio          string  `gorm:"not null" json:"bio"`
-	Availability string  `gorm:"not null" json:"availability"`
+	UserID       uint    `gorm:"primaryKey"`
+	User         User    `gorm:"foreignKey:UserID"`
+	Rating       float32 `gorm:"not null"`
+	Bio          string  `gorm:"not null"`
+	Availability string  `gorm:"not null"`
 	//TODO: Courses via many2many join table?
+}
+
+func (tutor Tutor) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		*User
+		Rating       float32  `json:"rating"`
+		Bio          string   `json:"bio"`
+		Availability []string `json:"availability"`
+	}{
+		User:         &tutor.User,
+		Rating:       tutor.Rating,
+		Bio:          tutor.Bio,
+		Availability: strings.FieldsFunc(tutor.Availability, func(r rune) bool { return r == ',' }),
+	})
 }
 
 /*type Availability struct {

--- a/backend/src/router.go
+++ b/backend/src/router.go
@@ -1,7 +1,6 @@
 package src
 
 import (
-	"strings"
 	"time"
 
 	"github.com/gin-contrib/cors"
@@ -55,13 +54,11 @@ func getCourses(c *gin.Context) {
 //     name: String
 //   }
 //   tutors: []Tutor {
-//     user: User {
-//       username: String
-//       firstname: String
-//       lastname: String
-//       email: String
-//       phone: String
-//     }
+//     username: String
+//     firstname: String
+//     lastname: String
+//     email: String
+//     phone: String
 //     rating: Float
 //     bio: String
 //     availability: []String
@@ -85,15 +82,10 @@ func getCoursesCode(c *gin.Context) {
 	//TODO: Native Gorm handling with Pluck (Preload/Join extract?)
 	var tutorings []Tutoring
 	DB.Joins("Tutor").Joins("LEFT JOIN users User ON id = Tutor__user_id").Preload("Tutor.User").Order("User.username").Find(&tutorings, "course_id = ?", courses[0].ID)
-	tutors := make([]gin.H, len(tutorings))
+	tutors := make([]Tutor, len(tutorings))
 	for i, tutoring := range tutorings {
 		//TODO: Limit the amount of data being returned
-		tutors[i] = gin.H{
-			"user":         tutoring.Tutor.User,
-			"rating":       tutoring.Tutor.Rating,
-			"bio":          tutoring.Tutor.Bio,
-			"availability": strings.FieldsFunc(tutoring.Tutor.Availability, func(r rune) bool { return r == ',' }), //TODO
-		}
+		tutors[i] = tutoring.Tutor
 	}
 
 	c.JSON(200, gin.H{
@@ -125,13 +117,11 @@ func getTutors(c *gin.Context) {
 //
 // Response Schema: {
 //   tutor: Tutor {
-//     user: User {
-//       username: String
-//       firstname: String
-//       lastname: String
-//       email: String
-//       phone: String
-//     }
+//     username: String
+//     firstname: String
+//     lastname: String
+//     email: String
+//     phone: String
 //     rating: Float
 //     bio: String
 //     availability: []String
@@ -166,12 +156,7 @@ func getTutorsUsername(c *gin.Context) {
 	}
 
 	c.JSON(200, gin.H{
-		"tutor": gin.H{
-			"user":         tutors[0].User,
-			"rating":       tutors[0].Rating,
-			"bio":          tutors[0].Bio,
-			"availability": strings.FieldsFunc(tutors[0].Availability, func(r rune) bool { return r == ',' }), //TODO
-		},
+		"tutor":   tutors[0],
 		"courses": courses,
 	})
 }
@@ -309,12 +294,15 @@ func postSignout(c *gin.Context) {
 //  - The user does not exist in the database (500)
 //
 // Response Schema: {
-//   user: User {
+//   profile: User | Tutor {
 //     username: String
 //     firstname: String
 //     lastname: String
 //     email: String
 //     phone: String
+//     rating?: Float
+//     bio?: String
+//     availability?: []String
 //   }
 // }
 // Error Schema: {
@@ -346,32 +334,38 @@ func getProfile(c *gin.Context) {
 		return
 	}
 
+	var tutors []Tutor
+	DB.Limit(1).Find(&tutors, "id = ?", users[0].ID)
+	if len(tutors) != 1 {
+		c.JSON(200, gin.H{
+			"profile": users[0],
+		})
+	}
+
 	c.JSON(200, gin.H{
-		"user": users[0],
+		"profile": tutors[0],
 	})
 }
-
 
 // JSON Schema for updating the profile
 // None or all of these attributes (accept for ID) can be used when send to PATCH /profile
 // for updating of the profile
 // Submit as { "attr": "val", "attr": "val" }
 type ClassItem struct {
-	Code string `json:"code"`
-	Action bool `json:"action"`
+	Code   string `json:"code"`
+	Action bool   `json:"action"`
 }
 
-type ProfileUpdateData struct { 
-	ID           uint    `json:"-"`
-	FirstName    string  `json:"firstname"`
-	LastName     string  `json:"lastname"`
-	Email        string  `json:"email"`
-	Phone        string  `json:"phone"`
-	Bio          string  `json:"bio"`
-	Availability string  `json:"availability"`
-	Tutoring     []ClassItem  `json:"tutoring"`
+type ProfileUpdateData struct {
+	ID           uint        `json:"-"`
+	FirstName    string      `json:"firstname"`
+	LastName     string      `json:"lastname"`
+	Email        string      `json:"email"`
+	Phone        string      `json:"phone"`
+	Bio          string      `json:"bio"`
+	Availability string      `json:"availability"`
+	Tutoring     []ClassItem `json:"tutoring"`
 }
-
 
 // Handler for PATCH /profile. Returns a success string if update operation is complete.
 // Errors if:
@@ -398,9 +392,8 @@ Check for sending extra json data that is not used (ie tutor stuff for nontutor)
 Currently assumes class actions are correct and frontend is telling the truth
 */
 
-
 func patchProfile(c *gin.Context) {
-	
+
 	token, err := c.Cookie("jwt")
 	if err != nil {
 		c.JSON(401, gin.H{
@@ -408,7 +401,7 @@ func patchProfile(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	claims, err := ParseJWT(token)
 	if err != nil {
 		c.JSON(500, gin.H{
@@ -416,7 +409,7 @@ func patchProfile(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	var edits ProfileUpdateData
 	if err := c.ShouldBindJSON(&edits); err != nil {
 		c.JSON(400, gin.H{
@@ -424,22 +417,22 @@ func patchProfile(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	var tutors []Tutor
 	DB.Joins("User").Find(&tutors, "User__username = ?", claims.Username)
-	
-	if len(tutors) > 0 { 
+
+	if len(tutors) > 0 {
 		if edits.Bio != "" {
-			tutors[0].Bio =  edits.Bio
+			tutors[0].Bio = edits.Bio
 		}
 		if edits.Availability != "" {
-			tutors[0].Availability =  edits.Availability
-		} 
+			tutors[0].Availability = edits.Availability
+		}
 		DB.Save(&tutors)
 	}
-	
+
 	if len(tutors) > 0 && len(edits.Tutoring) > 0 {
-		for i := 0; i < len(edits.Tutoring); i ++ {
+		for i := 0; i < len(edits.Tutoring); i++ {
 			var courses []Course
 			DB.Find(&courses, "code = ?", edits.Tutoring[i].Code)
 			if edits.Tutoring[i].Action {
@@ -452,25 +445,25 @@ func patchProfile(c *gin.Context) {
 			}
 		}
 	}
-	
+
 	//It's angry at me, so I'm doing it this less pretty way, even though the nice way used to work. Tutor class stuff put it to flames
 	//So long, old way. Rest in reeses pieces. You will be missed.
 	var users []User
 	DB.Find(&users, "username = ?", claims.Username)
 	if edits.FirstName != "" {
-		users[0].FirstName =  edits.FirstName
+		users[0].FirstName = edits.FirstName
 	}
 	if edits.LastName != "" {
-		users[0].LastName =  edits.LastName
+		users[0].LastName = edits.LastName
 	}
 	if edits.Email != "" {
-		users[0].Email =  edits.Email
+		users[0].Email = edits.Email
 	}
 	if edits.Phone != "" {
-		users[0].Phone =  edits.Phone
+		users[0].Phone = edits.Phone
 	}
 	DB.Save(&users)
 	//DB.Model(&users[0]).Updates(edits)
-	
+
 	c.JSON(200, gin.H{})
 }

--- a/backend/src/router.go
+++ b/backend/src/router.go
@@ -335,12 +335,13 @@ func getProfile(c *gin.Context) {
 	}
 
 	var tutors []Tutor
-	DB.Limit(1).Find(&tutors, "id = ?", users[0].ID)
+	DB.Limit(1).Find(&tutors, "user_id = ?", users[0].ID)
 	if len(tutors) != 1 {
 		c.JSON(200, gin.H{
 			"profile": users[0],
 		})
 	}
+	tutors[0].User = users[0]
 
 	c.JSON(200, gin.H{
 		"profile": tutors[0],

--- a/backend/src/router_test.go
+++ b/backend/src/router_test.go
@@ -8,7 +8,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 )
 
@@ -119,7 +118,7 @@ func (suite *RouterSuite) TestGetCoursesCode() {
 		`{
 			"course": {"code": "code", "name": "Name"},
 			"tutors": [
-				{"user": `+stringify(User{Username: "Username"})+`, "rating": 0.0, "bio": "", "availability": []}
+				`+stringify(Tutor{User: User{Username: "Username"}})+`
 			]
 		}`,
 	))
@@ -133,9 +132,9 @@ func (suite *RouterSuite) TestGetCoursesCode() {
 		`{
 			"course": {"code": "code", "name": "Name"},
 			"tutors": [
-				{"user": `+stringify(User{Username: "Alice"})+`, "rating": 0.0, "bio": "", "availability": []},
-				{"user": `+stringify(User{Username: "Bob"})+`, "rating": 0.0, "bio": "", "availability": []},
-				{"user": `+stringify(User{Username: "Clair"})+`, "rating": 0.0, "bio": "", "availability": []}
+				`+stringify(Tutor{User: User{Username: "Alice"}})+`,
+				`+stringify(Tutor{User: User{Username: "Bob"}})+`,
+				`+stringify(Tutor{User: User{Username: "Clair"}})+`
 			]
 		}`,
 	))
@@ -149,9 +148,9 @@ func (suite *RouterSuite) TestGetCoursesCode() {
 		`{
 			"course": {"code": "code", "name": "Name"},
 			"tutors": [
-				{"user": `+stringify(User{Username: "Alice"})+`, "rating": 0.0, "bio": "", "availability": []},
-				{"user": `+stringify(User{Username: "Bob"})+`, "rating": 0.0, "bio": "", "availability": []},
-				{"user": `+stringify(User{Username: "Clair"})+`, "rating": 0.0, "bio": "", "availability": []}
+				`+stringify(Tutor{User: User{Username: "Alice"}})+`,
+				`+stringify(Tutor{User: User{Username: "Bob"}})+`,
+				`+stringify(Tutor{User: User{Username: "Clair"}})+`
 			]
 		}`,
 	))
@@ -238,12 +237,7 @@ func (suite *RouterSuite) TestGetTutorsUsername() {
 	suite.Run("Empty Courses", test(
 		[]Tutoring{},
 		`{
-			"tutor": {
-				"user": `+stringify(tutor.User)+`,
-				"rating": `+stringify(tutor.Rating)+`,
-				"bio": `+stringify(tutor.Bio)+`,
-				"availability": `+stringify(strings.FieldsFunc(tutor.Availability, func(r rune) bool { return r == ',' }))+`
-            },
+			"tutor": `+stringify(tutor)+`,
 			"courses": []
 		}`,
 	))
@@ -253,12 +247,7 @@ func (suite *RouterSuite) TestGetTutorsUsername() {
 			{Course: Course{Code: "code", Name: "Name"}, Tutor: tutor},
 		},
 		`{
-			"tutor": {
-				"user": `+stringify(tutor.User)+`,
-				"rating": `+stringify(tutor.Rating)+`,
-				"bio": `+stringify(tutor.Bio)+`,
-				"availability": `+stringify(strings.FieldsFunc(tutor.Availability, func(r rune) bool { return r == ',' }))+`
-            },
+			"tutor": `+stringify(tutor)+`,
 			"courses": [
 				{"code": "code", "name": "Name"}
 			]
@@ -272,12 +261,7 @@ func (suite *RouterSuite) TestGetTutorsUsername() {
 			{Course: Course{Code: "3", Name: "Third"}, Tutor: tutor},
 		},
 		`{
-			"tutor": {
-				"user": `+stringify(tutor.User)+`,
-				"rating": `+stringify(tutor.Rating)+`,
-				"bio": `+stringify(tutor.Bio)+`,
-				"availability": `+stringify(strings.FieldsFunc(tutor.Availability, func(r rune) bool { return r == ',' }))+`
-            },
+			"tutor": `+stringify(tutor)+`,
 			"courses": [
 				{"code": "1", "name": "First"},
 				{"code": "2", "name": "Second"},
@@ -293,12 +277,7 @@ func (suite *RouterSuite) TestGetTutorsUsername() {
 			{Course: Course{Code: "1", Name: "First"}, Tutor: tutor},
 		},
 		`{
-			"tutor": {
-				"user": `+stringify(tutor.User)+`,
-				"rating": `+stringify(tutor.Rating)+`,
-				"bio": `+stringify(tutor.Bio)+`,
-				"availability": `+stringify(strings.FieldsFunc(tutor.Availability, func(r rune) bool { return r == ',' }))+`
-            },
+			"tutor": `+stringify(tutor)+`,
 			"courses": [
 				{"code": "1", "name": "First"},
 				{"code": "2", "name": "Second"},
@@ -448,9 +427,9 @@ func (suite *RouterSuite) TestGetProfile() {
 		w = GET("/profile", cookies...)
 		suite.Equal(200, w.Code)
 		suite.JSONEq(`{
-			"user": `+stringify(User{Username: "Username"})+`
+			"profile": `+stringify(User{Username: "Username"})+`
 		}`, w.Body.String())
-		
+
 	}))
 
 	suite.Run("Unauthenticated", manualSetupTest(func() {
@@ -475,42 +454,42 @@ func (suite *RouterSuite) TestPatchProfile() {
 		w = GET("/profile", cookies...)
 		suite.Equal(200, w.Code)
 		suite.JSONEq(`{
-			"user": `+stringify(User{Username: "Username"})+`
+			"profile": `+stringify(User{Username: "Username"})+`
 		}`, w.Body.String())
-		
-		w = PATCH("/profile", gin.H{"firstname": "Elk","lastname": "Cloner",}, cookies...)
+
+		w = PATCH("/profile", gin.H{"firstname": "Elk", "lastname": "Cloner"}, cookies...)
 		suite.Equal(200, w.Code)
-		
+
 		w = GET("/profile", cookies...)
 		suite.Equal(200, w.Code)
 		suite.JSONEq(`{
-			"user": `+stringify(User{Username: "Username", FirstName: "Elk", LastName: "Cloner"})+`
+			"profile": `+stringify(User{Username: "Username", FirstName: "Elk", LastName: "Cloner"})+`
 		}`, w.Body.String())
-		
+
 		w = PATCH("/profile", gin.H{"email": "coolbeans@aol.com"}, cookies...)
 		suite.Equal(200, w.Code)
-		
+
 		w = GET("/profile", cookies...)
 		suite.Equal(200, w.Code)
 		suite.JSONEq(`{
-			"user": `+stringify(User{Username: "Username", FirstName: "Elk", LastName: "Cloner", Email: "coolbeans@aol.com"})+`
+			"profile": `+stringify(User{Username: "Username", FirstName: "Elk", LastName: "Cloner", Email: "coolbeans@aol.com"})+`
 		}`, w.Body.String())
-		
+
 		w = PATCH("/profile", gin.H{"phone": "1234567890"}, cookies...)
 		suite.Equal(200, w.Code)
-		
+
 		w = GET("/profile", cookies...)
 		suite.Equal(200, w.Code)
 		suite.JSONEq(`{
-			"user": `+stringify(User{Username: "Username", FirstName: "Elk", LastName: "Cloner", Email: "coolbeans@aol.com", Phone: "1234567890"})+`
+			"profile": `+stringify(User{Username: "Username", FirstName: "Elk", LastName: "Cloner", Email: "coolbeans@aol.com", Phone: "1234567890"})+`
 		}`, w.Body.String())
 	}))
 
 	suite.Run("Unauthenticated", manualSetupTest(func() {
 		//w := GET("/profile")
 		//suite.Equal(401, w.Code)
-		
-		w := PATCH("/profile", gin.H{"firstname": "Elk","lastname": "Cloner",})
+
+		w := PATCH("/profile", gin.H{"firstname": "Elk", "lastname": "Cloner"})
 		suite.Equal(401, w.Code)
 	}))
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,23 +11,14 @@ import ErrorPage from "./components/ErrorPage";
 import TutorPage from "./components/TutorPage";
 
 function App() {
-  const [name, setName] = useState(null);
-  const [user, setUser] = useState(null);
+  const [profile, setProfile] = useState(null);
 
   useEffect(() => {
     fetch("/profile", {
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
     }).then(r => r.json()).then(r => {
-      //console.log("setName ", r.user?.username)
-      setName(r.user?.username)
-      setUser({
-        username: r.user.username,
-        firstname: r.user.firstname,
-        lastname: r.user.lastname,
-        email: r.user.email,
-        phone: r.user.phone
-      })
+      setProfile(r.profile)
     })
   }, []);
 
@@ -36,14 +27,14 @@ function App() {
   return (
     <div>
       <BrowserRouter>
-        <Navbar name={name} setName={setName} />
+        <Navbar profile={profile} setProfile={profile} />
         <Routes>
           <Route path="/" exact element={<LandingPage />} />
           <Route path="/courses" element={<CoursesPage />} />
-          <Route path="/courses/:code" element={<CoursePage username={name} />} />
-          <Route path="/signup" element={<SignupPage setName={setName} />} />
-          <Route path="/signin" element={<SigninPage setName={setName} />} />
-          <Route path="/profile" element={<ProfilePage user={user} />} />
+          <Route path="/courses/:code" element={<CoursePage profile={profile} />} />
+          <Route path="/signup" element={<SignupPage />} />
+          <Route path="/signin" element={<SigninPage />} />
+          <Route path="/profile" element={<ProfilePage profile={profile} />} />
           <Route path="/tutors/:username" element={<TutorPage />} />
           <Route path= "*" element={<ErrorPage />} />
         </Routes>

--- a/frontend/src/components/CoursePage.js
+++ b/frontend/src/components/CoursePage.js
@@ -5,7 +5,7 @@ import {ThreeDots} from 'react-loader-spinner';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 
-export default function CoursePage({ username }) {
+export default function CoursePage({ profile }) {
   const params = useParams();
   const [isLoading, setLoading] = React.useState(true);
   const [data, setData] = React.useState(null);
@@ -98,8 +98,8 @@ export default function CoursePage({ username }) {
                   title: "SearchBarInput",
                 }}
               />
-              {username !== null &&
-                (data.tutors.every((t) => t.user.username !== username) ? (
+              {profile !== null &&
+                (data.tutors.every((t) => t.username !== profile.username) ? (
                   <Button
                     aria-label="AddIcon"
                     variant="contained"
@@ -167,20 +167,20 @@ export default function CoursePage({ username }) {
               data.tutors
                 .filter(
                   (t) =>
-                    (t.user.firstname + " " + t.user.lastname)
+                    (t.firstname + " " + t.lastname)
                       .toUpperCase()
                       .includes(filter) ||
                     t.availability.some((a) => a.toUpperCase().includes(filter))
                 )
                 .map((t) => (
                   <Link
-                    key={t.user.username}
-                    to={`/tutors/${t.user.username}`}
+                    key={t.username}
+                    to={`/tutors/${t.username}`}
                     style={{ textDecoration: "none", color: "blue" }}
                   >
                     <Card>
                       <CardHeader
-                        title={t.user.firstname + " " + t.user.lastname}
+                        title={t.firstname + " " + t.lastname}
                         subheader={
                           <Rating
                             name="read-only"

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -17,7 +17,7 @@ import { Link as ScrollLink } from 'react-scroll'
 const pages = ['About Us', 'Service', 'Contact Us'];
 //const settings = ['Profile', 'Finance', 'Logout'];
 
-const Navbar = ({ name, setName }) => {
+const Navbar = ({ profile, setProfile }) => {
   const [anchorElNav, setAnchorElNav] = React.useState(null);
   const [anchorElUser, setAnchorElUser] = React.useState(null);
 
@@ -43,12 +43,12 @@ const Navbar = ({ name, setName }) => {
       credentials: 'include',
     });
 
-    setName(null);
+    setProfile(null);
     handleCloseUserMenu()
   }
 
   let buttons;
-  if (name) {
+  if (profile !== null) {
 
     buttons = (
       <Box sx={{ flexGrow: 0 }}>

--- a/frontend/src/components/ProfilePage.js
+++ b/frontend/src/components/ProfilePage.js
@@ -6,7 +6,7 @@ import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Grid";
 import { ThreeDots } from "react-loader-spinner";
 
-export default function ProfilePage({ user }) {
+export default function ProfilePage({ profile }) {
   const [updated, setUpdated] = React.useState({});
 
   function onSubmit(event) {
@@ -28,7 +28,7 @@ export default function ProfilePage({ user }) {
     setUpdated((fields) => ({ ...fields, [field]: value }));
   }
 
-  if (user === null) {
+  if (profile === null) {
     return (
       <div className="loadingContainer">
         <ThreeDots type="ThreeDots" color="#00b22d" height={100} width={100} />
@@ -67,7 +67,7 @@ export default function ProfilePage({ user }) {
                   title="firstname"
                   id="firstname"
                   label="First Name"
-                  defaultValue={user.firstname ?? ""}
+                  defaultValue={profile.firstname ?? ""}
                   onChange={(e) => update("firstname", e.target.value)}
                   sx={{ m: 1 }}
                 />
@@ -77,7 +77,7 @@ export default function ProfilePage({ user }) {
                   title="email"
                   id="email"
                   label="Email Address"
-                  defaultValue={user.email ?? ""}
+                  defaultValue={profile.email ?? ""}
                   onChange={(e) => update("email", e.target.value)}
                   sx={{ m: 1 }}
                 />
@@ -89,7 +89,7 @@ export default function ProfilePage({ user }) {
                   title="lastname"
                   id="lastname"
                   label="Last Name"
-                  defaultValue={user.lastname ?? ""}
+                  defaultValue={profile.lastname ?? ""}
                   onChange={(e) => update("lastname", e.target.value)}
                   sx={{ m: 1, pl: 1 }}
                 />
@@ -100,7 +100,7 @@ export default function ProfilePage({ user }) {
                   title="phone"
                   id="phone"
                   label="Phone Number"
-                  defaultValue={user.phone ?? ""}
+                  defaultValue={profile.phone ?? ""}
                   onChange={(e) => update("phone", e.target.value)}
                   sx={{ m: 1, pl: 1 }}
                 />

--- a/frontend/src/components/SigninPage.js
+++ b/frontend/src/components/SigninPage.js
@@ -15,7 +15,7 @@ import { Link } from "react-router-dom";
 
 const theme = createTheme();
 
-export default function SigninPage({ setName }) {
+export default function SigninPage() {
   const navigate = useNavigate();
   const [username, setUsername] = React.useState("");
   const [password, setPassword] = React.useState("");
@@ -30,7 +30,6 @@ export default function SigninPage({ setName }) {
     })
       .then(res => {
         if (res.status === 200) {
-          setName(username);
           navigate("/");
         } else if (res.status === 401) {
           setInvalid(true);

--- a/frontend/src/components/SignupPage.js
+++ b/frontend/src/components/SignupPage.js
@@ -15,7 +15,7 @@ import { Link } from "react-router-dom";
 
 const theme = createTheme();
 
-export default function SignupPage({ setName }) {
+export default function SignupPage() {
   const navigate = useNavigate();
   const [username, setUsername] = React.useState("");
   const [password, setPassword] = React.useState("");
@@ -45,7 +45,6 @@ export default function SignupPage({ setName }) {
       })
         .then(res => {
           if (res.status === 200) {
-            setName(username);
             navigate("/");
           } else if (res.status === 401) {
             setUsernameTaken(true);

--- a/frontend/src/components/TutorPage.js
+++ b/frontend/src/components/TutorPage.js
@@ -88,7 +88,7 @@ export default function TutorPage() {
               width: { xs: 50, md: 100 },
               height: { xs: 50, md: 100 },
             }}
-            alt={data.tutor.user.firstname + " " + data.tutor.user.lastname}
+            alt={data.tutor.firstname + " " + data.tutor.lastname}
           />
           <Typography
             sx={{
@@ -98,7 +98,7 @@ export default function TutorPage() {
               },
             }}
           >
-            {data.tutor.user.firstname + " " + data.tutor.user.lastname}
+            {data.tutor.firstname + " " + data.tutor.lastname}
           </Typography>
         </Stack>
         <Stack
@@ -119,7 +119,7 @@ export default function TutorPage() {
             }}
             color="gray"
           >
-            @{data.tutor.user.username}
+            @{data.tutor.username}
           </Typography>
           {<Rating title="Rating" value={data.tutor.rating} readOnly />}
         </Stack>
@@ -136,7 +136,7 @@ export default function TutorPage() {
             },
           }}
         >
-          {data.tutor.user.email}
+          {data.tutor.email}
         </Typography>
         <Typography
           title="Phone_Number"
@@ -151,7 +151,7 @@ export default function TutorPage() {
             },
           }}
         >
-          {data.tutor.user.phone}
+          {data.tutor.phone}
         </Typography>
         <Box
           title="Bio"

--- a/frontend/src/tests/components/CoursePage.test.js
+++ b/frontend/src/tests/components/CoursePage.test.js
@@ -32,7 +32,7 @@ describe("CoursePage", () => {
       tutors: [],
     });
     await waitFor(async () => {
-      const component = render(<CoursePage />, { wrapper: MemoryRouter });
+      const component = render(<CoursePage profile={null} />, { wrapper: MemoryRouter });
       const loadingContainer =
         component.container.querySelector(".loadingContainer");
       expect(loadingContainer).not.toBe(null);
@@ -51,7 +51,7 @@ describe("CoursePage", () => {
         tutors: tutors.map((t) => createTutor(t)),
       });
       const component = await waitFor(async () => {
-        return render(<CoursePage />, { wrapper: MemoryRouter });
+        return render(<CoursePage profile={null} />, { wrapper: MemoryRouter });
       });
       const tutorlist = component.queryByTitle("tutorlist");
       if (tutors.length === 0) {
@@ -81,7 +81,7 @@ describe("CoursePage", () => {
             <Routes>
               <Route
                 path={"/courses/:code"}
-                element={<CoursePage username="Username" />}
+                element={<CoursePage profile={createTutor({username: "Username"})} />}
               />
             </Routes>
           </MemoryRouter>
@@ -115,10 +115,5 @@ function createTutor({
   rating = 0.0,
   availability = [],
 }) {
-  return {
-    user: { username, firstname, lastname, email, phone },
-    bio,
-    rating,
-    availability,
-  };
+  return {username, firstname, lastname, email, phone, bio, rating, availability};
 }

--- a/frontend/src/tests/components/ProfilePage.test.js
+++ b/frontend/src/tests/components/ProfilePage.test.js
@@ -21,7 +21,7 @@ beforeAll(() => {
 describe("ProfilePage", () => {
   test("loading", async () => {
     const component = await waitFor(async () => {
-      return render(<ProfilePage user={null} />, { wrapper: MemoryRouter });
+      return render(<ProfilePage profile={null} />, { wrapper: MemoryRouter });
     });
     const loadingContainer =
       component.container.querySelector(".loadingContainer");
@@ -32,7 +32,7 @@ describe("ProfilePage", () => {
     fetch.mockResponseValue({});
     const component = await waitFor(async () => {
       return render(
-        <ProfilePage user={createUser({ username: "Username" })} />,
+        <ProfilePage profile={createUser({ username: "Username" })} />,
         { wrapper: MemoryRouter }
       );
     });
@@ -51,7 +51,7 @@ describe("ProfilePage", () => {
 
       const component = await waitFor(async () => {
         return render(
-          <ProfilePage user={createUser({ username: "Username" })} />,
+          <ProfilePage profile={createUser({ username: "Username" })} />,
           { wrapper: MemoryRouter }
         );
       });
@@ -81,7 +81,7 @@ describe("ProfilePage", () => {
 
       const component = await waitFor(async () => {
         return render(
-          <ProfilePage user={createUser({ username: "Username" })} />,
+          <ProfilePage profile={createUser({ username: "Username" })} />,
           { wrapper: MemoryRouter }
         );
       });
@@ -115,9 +115,7 @@ describe("ProfilePage", () => {
 
       const component = await waitFor(async () => {
         return render(
-          <ProfilePage
-            user={createUser({ username: "Username", firstname: "First" })}
-          />,
+          <ProfilePage profile={createUser({ username: "Username", firstname: "First" })} />,
           { wrapper: MemoryRouter }
         );
       });

--- a/frontend/src/tests/components/SigninPage.test.js
+++ b/frontend/src/tests/components/SigninPage.test.js
@@ -23,7 +23,7 @@ describe("SigninPage", () => {
     fetch.mockResponseValue({});
 
     const component = await waitFor(async () => {
-      return render(<SigninPage setName={jest.fn()} />, { wrapper: MemoryRouter });
+      return render(<SigninPage />, { wrapper: MemoryRouter });
     });
 
     await waitFor(async () => {
@@ -43,27 +43,25 @@ describe("SigninPage", () => {
 
   test("fetch resolved", async () => {
     fetch.mockResponseValue({});
-    const mockSetName = jest.fn();
 
     const component = await waitFor(async () => {
-      return render(<SigninPage setName={mockSetName} />, { wrapper: MemoryRouter });
+      return render(<SigninPage />, { wrapper: MemoryRouter });
     });
 
     await waitFor(async () => {
       fireEvent.submit(component.getByTitle("submit"));
     });
 
-    expect(mockSetName).not.toHaveBeenCalled();
+    //TODO: Assert result
     //expect(window.location.pathname).toBe("/");
   });
 
   test("fetch rejected", async () => {
     console.error = jest.fn(); //TODO: State management
     fetch.mockRejectedValue(new Error("expected"));
-    const mockSetName = jest.fn();
 
     const component = await waitFor(async () => {
-      return render(<SigninPage setName={mockSetName} />, { wrapper: MemoryRouter });
+      return render(<SigninPage />, { wrapper: MemoryRouter });
     });
 
     await waitFor(async () => {
@@ -71,7 +69,6 @@ describe("SigninPage", () => {
     });
 
     expect(console.error).toHaveBeenCalledWith("expected");
-    expect(mockSetName).not.toHaveBeenCalled();
     //expect(window.location.pathname).toBe("/signin");
   });
 });

--- a/frontend/src/tests/components/SignupPage.test.js
+++ b/frontend/src/tests/components/SignupPage.test.js
@@ -23,7 +23,7 @@ describe("SignupPage", () => {
     fetch.mockResponseValue({});
 
     const component = await waitFor(async () => {
-      return render(<SignupPage setName={jest.fn()} />, { wrapper: MemoryRouter });
+      return render(<SignupPage />, { wrapper: MemoryRouter });
     });
 
     await waitFor(async () => {
@@ -43,27 +43,25 @@ describe("SignupPage", () => {
 
   test("fetch resolved", async () => {
     fetch.mockResponseValue({});
-    const mockSetName = jest.fn();
 
     const component = await waitFor(async () => {
-      return render(<SignupPage setName={mockSetName} />, { wrapper: MemoryRouter });
+      return render(<SignupPage />, { wrapper: MemoryRouter });
     });
 
     await waitFor(async () => {
       fireEvent.submit(component.getByTitle("submit"));
     });
 
-    expect(mockSetName).not.toHaveBeenCalled();
+    //TODO: Assert result
     //expect(window.location.pathname).toBe("/");
   });
 
   test("fetch rejected", async () => {
     console.error = jest.fn(); //TODO: State management
     fetch.mockRejectedValue(new Error("expected"));
-    const mockSetName = jest.fn();
 
     const component = await waitFor(async () => {
-      return render(<SignupPage setName={mockSetName} />, { wrapper: MemoryRouter });
+      return render(<SignupPage />, { wrapper: MemoryRouter });
     });
 
     await waitFor(async () => {
@@ -71,7 +69,6 @@ describe("SignupPage", () => {
     });
 
     // expect(console.error).toHaveBeenCalledWith("expected");
-    expect(mockSetName).not.toHaveBeenCalled();
     //expect(window.location.pathname).toBe("/signin");
   });
 });

--- a/frontend/src/tests/components/TutorPage.test.js
+++ b/frontend/src/tests/components/TutorPage.test.js
@@ -62,10 +62,5 @@ function createTutor({
   rating = 0.0,
   availability = [],
 }) {
-  return {
-    user: { username, firstname, lastname, email, phone },
-    bio,
-    rating,
-    availability,
-  };
+  return {username, firstname, lastname, email, phone, bio, rating, availability};
 }


### PR DESCRIPTION
This treats Tutor as a proper subtype of User in API responses, simplifying the handling of relevant routes and avoiding duplicate data in responses.

The frontend has not been updated for this yet; the PATCH /profile route and frontend profile page have outstanding PRs that should be merged first to minimize unnecessary changes.