### PR TITLE
Add backend username/password validation and cleanup frontend

### DIFF
--- a/backend/src/router_test.go
+++ b/backend/src/router_test.go
@@ -315,6 +315,16 @@ func (suite *RouterSuite) TestSignup() {
 		suite.Equal(400, w.Code)
 	}))
 
+	suite.Run("Invalid Request (Invalid Username)", manualSetupTest(func() {
+		w := test("!@#$%^&*()", "Password")
+		suite.Equal(400, w.Code)
+	}))
+
+	suite.Run("Invalid Request (Invalid Username)", manualSetupTest(func() {
+		w := test("Username", "short")
+		suite.Equal(400, w.Code)
+	}))
+
 	/*
 		//TODO: Error on unknown fields
 		suite.Run("Invalid Request (Unknown Field)", manualSetupTest(func() {

--- a/frontend/src/components/SignupPage.js
+++ b/frontend/src/components/SignupPage.js
@@ -26,18 +26,9 @@ export default function SignupPage() {
 
   function onSubmit(event) {
     event.preventDefault();
-
-    //console.log(username + password)
-
-    const usernameRegex = new RegExp("[a-zA-Z0-9_]{5,20}");
-    const passwordRegex = new RegExp(
-      "[a-zA-Z0-9-_\\!\\@\\#\\$\\%\\^&\\*\\.]{7,30}"
-    );
-
-    let u = usernameRegex.test(username);
-    let p = passwordRegex.test(password);
-
-    if (u === true && p === true) {
+    const u = /^[A-Za-z][A-Za-z0-9_\-.]{0,71}$/.test(username);
+    const p = /^.{8,72}$/.test(password);
+    if (u && p) {
       Utils.fetchJson("/signup", {
         method: "POST",
         body: JSON.stringify({ username, password }),
@@ -48,26 +39,14 @@ export default function SignupPage() {
         .catch((error) => {
           if (error.status === 401) {
             setUsernameTaken(true);
-            setIncorrectUsername(false);
-            setIncorrectPassword(false);
           } else {
             alert(`Error ${error.status ?? "(Unexpected)"}: ${error.message}`);
           }
         });
-    } else if (u === false && p === false) {
-      setUsernameTaken(false);
-      setIncorrectUsername(true);
-      setIncorrectPassword(true);
-    } else if (u === false) {
-      setUsernameTaken(false);
-      setIncorrectUsername(true);
-      setIncorrectPassword(false);
     } else {
-      setUsernameTaken(false);
-      setIncorrectUsername(false);
-      setIncorrectPassword(true);
+      setIncorrectUsername(!u);
+      setIncorrectPassword(!p);
     }
-    //console.log(res)
   }
 
   return (
@@ -87,27 +66,22 @@ export default function SignupPage() {
           }}
         >
           <div>
-            {usernameTaken ? (
+            {usernameTaken && (
               <Alert severity="error" sx={{ mb: 1 }}>
-                Username already taken!
+                Username already exists.
               </Alert>
-            ) : (
-              <div />
             )}
-            {incorrectUsername ? (
+            {incorrectUsername && (
               <Alert severity="error" sx={{ mb: 1 }}>
-                Username should contain 5-20 alphanumeric or _ characters.
-              </Alert>
-            ) : (
-              <div />
-            )}
-            {incorrectPassword ? (
-              <Alert severity="error">
-                Password should contain 7-30 alphanumeric or -_!@#$%^&*.
+                Username must start with a letter, can only contain alphanumeric
+                characters and '_', '-', or '.', and cannot exceed 72
                 characters.
               </Alert>
-            ) : (
-              <div />
+            )}
+            {incorrectPassword && (
+              <Alert severity="error">
+                Password must contain 8-72 characters.
+              </Alert>
             )}
           </div>
           <Avatar sx={{ m: 1, bgcolor: "secondary.main" }}>


### PR DESCRIPTION
This does not validate username/password for signin, since it isn't needed and isn't done on the frontend either (though would be preferable for more descriptive errors).

For the actual validation, username must start with a letter (standard requirement for clarity), only supports alphanumeric and _-. characters (common characters and dividers that are url safe), and no more than 72 character (to match password length). The password has no character restrictions (restricting or requiring certain characters lowers security and can be problematic for password managers) and must be 8-72 characters (8 is a reasonable starting point, 72 appears to be the limit for bcyrpt).